### PR TITLE
I2C Write Multiple Data Bytes

### DIFF
--- a/embedded/drivers/include/i2c.h
+++ b/embedded/drivers/include/i2c.h
@@ -27,6 +27,7 @@ typedef struct {
 int i2c_begin(i2c_settings *i2c);
 int write_byte_i2c(i2c_settings *i2c, unsigned char reg);
 int write_data_i2c(i2c_settings *i2c, unsigned char reg, char value);
+int write_multiple_bytes_i2c(i2c_settings *i2c, unsigned char reg, char *values, int size);
 int read_i2c(i2c_settings *i2c, unsigned char *readBuffer, int bufferSize);
 
 #endif 

--- a/embedded/drivers/src/i2c.c
+++ b/embedded/drivers/src/i2c.c
@@ -42,6 +42,19 @@ int write_data_i2c(i2c_settings *i2c, unsigned char reg, char value) {
 	return 0;
 }
 
+int write_multiple_bytes_i2c(i2c_settings *i2c, unsigned char reg, char *values, int size){
+	unsigned char buf[size + 1];
+	buf[0] = reg;
+	for(int i = 0; i < size; i++){
+		buf[i+1] = values[i];
+	}
+	if (write(i2c->fd, buf, size+1) != size+1) {
+		fprintf(stderr, "I2C write multiple data bytes error\n");
+		return 1;
+	}
+	
+}
+
 int read_i2c(i2c_settings *i2c, unsigned char *readBuffer, int bufferSize) {
 	if (read(i2c->fd, readBuffer, bufferSize) != bufferSize) {
 		fprintf(stderr, "I2C data read error\n");

--- a/embedded/drivers/src/i2c.c
+++ b/embedded/drivers/src/i2c.c
@@ -52,7 +52,7 @@ int write_multiple_bytes_i2c(i2c_settings *i2c, unsigned char reg, char *values,
 		fprintf(stderr, "I2C write multiple data bytes error\n");
 		return 1;
 	}
-	
+	return 0;
 }
 
 int read_i2c(i2c_settings *i2c, unsigned char *readBuffer, int bufferSize) {


### PR DESCRIPTION
Tentative fix for issue #48 where we need to write multiple data bytes to the I2C device. This compiles but will require further testing.

Usage should be fairly straightforward. Returns 0 on success, 1 on failure
