### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: test
+      run: make && make examples


### PR DESCRIPTION
Formally adds Actions CI to master branch. Doesn't update README due to a to a bug displaying the badge.

Current version uses both Travis & Actions.